### PR TITLE
Add Slint-based task manager skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rust-slint"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+slint = { version = "1.3", default-features = false, features = ["backend-winit", "renderer-femtovg", "compat-1-2"] }
+rusqlite = { version = "0.29", features = ["bundled"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[build-dependencies]
+slint-build = "1.3"

--- a/assets/slint-logo.png
+++ b/assets/slint-logo.png
@@ -1,0 +1,182 @@
+<!doctype html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+        <meta name="author" content="SixtyFPS GmbH" />
+
+        <!--====== Favicon Icon ======-->
+        <link rel="shortcut icon" href="https://slint.dev/assets/img/favicon.ico">
+        <link rel="icon" type="image/x-icon" href="https://slint.dev/assets/img/favicon.svg">
+
+        <!-- ===== All CSS files ===== -->
+        <link rel="stylesheet" href="https://slint.dev/assets/css/style.css?v=1.15.1" async/>
+        
+
+        <!-- ===== Header from individual pages ===== -->
+        
+        <title>404 page not found</title>
+        <meta name="description" content="Error: 404 page not found." />
+    
+    </head>
+
+    <body>
+        <script>
+            /* Check if dark theme is selected */
+            if (localStorage.getItem('theme') === 'dark') {
+                document.documentElement.classList.add('dark');
+            }
+            else if (localStorage.getItem('theme') === 'light') {
+                document.documentElement.classList.add('light');
+            }
+        </script>
+
+        <div class="wrap">
+            <!-- ====== Header Start ====== -->
+            <header class="top">
+                <div class="header-wrap">
+
+                    <a href="https://slint.dev/index.html" class="logo">Slint</a>
+
+                    <nav class="main-navi">
+
+                        <ul>
+                            <li class="navi-item-has-children" id="use-cases"><a href="#">Use Cases</a>
+                                <ul>
+                                    <li id="demos"><a href="https://slint.dev/demos.html">Demos</a></li>
+                                    <li id="supported-boards"><a href="https://slint.dev/supported-boards.html">Embedded</a></li>
+                                    <li id="use-cases"><a href="https://slint.dev/cross-platform.html">Cross Platform</a></li>
+                                </ul>
+                            </li>
+                            <li id="docs"><a href="https://slint.dev/docs.html">Docs</a></li>
+                            <!-- <li id="docs"><a href="https://slint.dev/services.html">Services</a></li> -->
+                            <li id="pricing"><a href="https://slint.dev/pricing.html">Pricing</a></li>
+                            <li id="success"><a href="https://slint.dev/showcase.html">Showcase</a></li>
+                            <li id="blog"><a href="https://slint.dev/blog">Blog</a></li>
+                            <!-- <li class="search"><a href="https://slint.dev/search-results.html">Search</a></li> -->
+                            <li class="theme theme-light"><a href="#">Theme</a></li>
+                            <li class="github"><a href="https://github.com/slint-ui/slint" target="_blank">GitHub</a></li>
+                            <!-- <li class="btn btn-blue"><a href="https://slint.dev/checkout.html?plan=ent&interval=month">Start for Free</a></li> -->
+                            <li class="btn btn-blue"><a href="https://docs.slint.dev/latest/docs/slint/">Get Started</a></li>
+                            <li class="btn btn-white"><a href="https://slint.dev/contact.html">Contact Us</a></li>
+                        </ul>
+
+                    </nav>
+
+                    <!-- <a href="https://slint.dev/search-results.html" class="search-mobile">Search</a> -->
+
+                    <button class="hamburger" aria-label="menu" aria-expanded="false" aria-controls="nav">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                    </button>
+
+                </div><!-- .header-wrap -->
+            </header>
+            <!-- ====== Header End ====== -->
+
+            
+        <main>
+
+            <!--
+            Section blocks on this page:
+            - one-column
+            - one-column (with blue background)
+            -->
+
+            <section class="one-column medium-narrow">
+                <h2 class="subtitle">Oops!</h2>
+                <h1>Error 404: Page not found</h1>
+                <p class="intro">Sorry! The page you are looking for either does not exist or has been moved. Please feel free to report this in our <a href="https://github.com/slint-ui/slint/labels/website" target="_blank">Github issues.</a></p>
+                <p>Join <a href="https://github.com/slint-ui/slint/discussions" target="_blank">Github discussions</a> for general chat or questions. We chat in our <a href="https://chat.slint.dev/" target="_blank">Mattermost instance</a> where you are welcome to listen in or ask your questions. You can follow us on <a href="https://twitter.com/slint_ui" target="_blank">Twitter</a>, <a href="https://fosstodon.org/@slint" target="_blank">Mastodon</a> and <a href="https://www.linkedin.com/company/slint-ui/" target="_blank">LinkedIn.</a></p>
+            </section>
+
+        </main>
+    
+
+            <!-- ====== Footer Start ====== -->
+            <footer>
+                <div class="col-wrap">
+                    <div class="col-6">
+                        <p><a href="https://slint.dev/index.html"><img src="https://slint.dev/assets/img/slint-logo.svg" alt="Slint" width="141" height="47" class="footer-logo"></a></p>
+                        <p class="some-links" style="margin-bottom: 0;">
+                            <a href="https://twitter.com/slint_ui" target="_blank"><img src="https://slint.dev/assets/img/icon-twitter.svg" alt="Twitter" width="40" height="40"></a>
+                            <a href="https://www.linkedin.com/company/slint-ui/" target="_blank"><img src="https://slint.dev/assets/img/icon-linkedin.svg" alt="Linkedin" width="40" height="40"></a>
+                            <a rel="me" href="https://fosstodon.org/@slint" target="_blank"><img src="https://slint.dev/assets/img/icon-mastodon.svg" alt="Mastodon" width="40" height="40"></a>
+                            <a href="https://bsky.app/profile/slint.dev" target="_blank"><img src="https://slint.dev/assets/img/icon-bsky.svg" alt="Bluesky" width="40" height="40"></a>
+                            <!-- <a href="https://github.com/slint-ui/slint/discussions" target="_blank"><img src="https://slint.dev/assets/img/icon-github.svg" alt="Github Discussions" width="40" height="40"></a> -->
+                            <!-- <a href="https://chat.slint.dev/" target="_blank"><img src="https://slint.dev/assets/img/icon-some.svg" alt="" width="40" height="40"></a> -->
+                        </p>
+                        <p style="display: flex; align-items: left; flex-direction: column;" ><img src="https://slint.dev/assets/img/BSFZ_Siegel_RGB.svg" alt="BSFZ Siegel" style="width: 30%;"><img src="https://slint.dev/assets/img/annual-ross-index.svg" data-darkimg="https://slint.dev/assets/img/annual-ross-index-light.svg" data-lightimg="https://slint.dev/assets/img/annual-ross-index.svg" alt="Annual Ross index" style="width: 60%;"></p>
+                    </div><!-- .col-6 -->
+                    <div class="col-6">
+                        <dl>
+                            <dt style="color: var(--light, var(--color_dark_gray)) var(--dark, var(--color_light_gray_2));">About</dt>
+                            <dd><a href="https://slint.dev/about-us.html">Us</a></dd>
+                            <dd><a href="https://slint.dev/events.html">Events</a></dd>
+                            <dd><a href="https://slint.dev/careers.html">Careers</a></dd>
+                            <dd><a href="https://slint.dev/investors.html">Investors</a></dd>
+                            <dd><a href="https://slint.dev/imprint.html">Imprint &amp; Privacy</a></dd>
+                        </dl>
+                    </div><!-- .col-6 -->
+                    <div class="col-6">
+                        <dl>
+                            <dt style="color: var(--light, var(--color_dark_gray)) var(--dark, var(--color_light_gray_2));">Explore</dt>
+                            <dd><a href="https://slint.dev/supported-boards.html">Embedded</a></dd>
+                            <dd><a href="https://slint.dev/cross-platform.html#desktop-applications">Desktop</a></dd>
+                            <dd><a href="https://slint.dev/demos.html">Demos</a></dd>
+                            <dd><a href="https://slint.dev/terms-and-conditions.html">Terms & Conditions</a></dd>
+                            <dd><a href="https://slint.dev/brand-guidelines.html">Brand Guidelines</a></dd>
+                        </dl>
+                    </div><!-- .col-6 -->
+                    <div class="col-6">
+                        <dl>
+                            <dt style="color: var(--light, var(--color_dark_gray)) var(--dark, var(--color_light_gray_2));">Markets</dt>
+                            <dd><a href="https://slint.dev/cross-platform.html#automotive-applications">Automotive</a></dd>
+                            <dd><a href="https://slint.dev/cross-platform.html#consumer-applications">Consumer</a></dd>
+                            <dd><a href="https://slint.dev/cross-platform.html#industrial-applications">Industrial</a></dd>
+                            <dd><a href="https://slint.dev/cross-platform.html#medical-applications">Medical</a></dd>
+                            <dd><a href="https://slint.dev/showcase.html">Showcase</a></dd>
+                        </dl>
+                    </div><!-- .col-6 -->
+                    <div class="col-6">
+                        <dl>
+                            <dt style="color: var(--light, var(--color_dark_gray)) var(--dark, var(--color_light_gray_2));">Compare</dt>
+                            <dd><a href="https://slint.dev/alternative-to-qt.html">Qt</a></dd>
+                            <dd><a href="https://slint.dev/alternative-to-lvgl.html">LVGL</a></dd>
+                            <dd><a href="https://slint.dev/alternative-to-flutter.html">Flutter</a></dd>
+                            <dd><a href="https://slint.dev/alternative-to-electron.html">Electron</a></dd>
+                            <dd><a href="https://slint.dev/declarative-rust-gui.html">Rust GUI Toolkits</a></dd>
+                        </dl>
+                    </div><!-- .col-6 -->
+                    <div class="col-6">
+                        <dl>
+                            <dt style="color: var(--light, var(--color_dark_gray)) var(--dark, var(--color_light_gray_2));">Contact us</dt>
+                            <dd><a href="https://cal.slint.dev/aurindam">Schedule Meeting</a></dd>
+                            <dd><a href="/cdn-cgi/l/email-protection#8ee7e0e8e1cefde2e7e0faa0eaebf8b1fdfbece4ebedfab3cde1e0faefedfaabbcbee8fce1e3abbcbed9ebecfde7faeb">Email</a></dd>
+                            <dd><a href="https://chat.slint.dev">Chat</a></dd>
+                            <dd><a href="https://slint.dev/events.html">Events</a></dd>
+                            <dd><a href="https://slint.dev/partners.html">Partners</a></dd>
+                            <dd hidden><a href="#">Twitter</a></dd>
+                            <dd hidden><a href="#">Mastodon</a></dd>
+                            <dd hidden><a href="#">Linkedin</a></dd>
+                        </dl>
+                    </div><!-- .col-6 -->
+                </div>
+                <div class="col-wrap">
+                    <div class="col-1">
+                        <p>Copyright &copy; 2025 SixtyFPS GmbH</p>
+                    </div><!-- .col-1 -->
+                </div>
+            </footer>
+            <!-- ====== Footer End ====== -->
+        </div><!-- .wrap -->
+
+        <!-- ====== All Javascript Files ====== -->
+        <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script src="https://slint.dev/assets/js/script.js?ver=1.4.0"></script>
+        
+    </body>
+
+</html>

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    slint_build::compile("ui/main.slint").unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,219 @@
+use slint::{ComponentHandle, ModelRc, VecModel, Model};
+use rusqlite::{Connection, params};
+use chrono::Local;
+use std::{rc::Rc, cell::RefCell};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+
+slint::include_modules!();
+
+#[derive(Clone)]
+struct TaskData {
+    id: i64,
+    title: String,
+    created: String,
+    tracker: String,
+    branch: String,
+    review: String,
+    commit: String,
+    notes: String,
+    current: bool,
+}
+
+fn init_db(conn: &Connection) {
+    conn.execute("CREATE TABLE IF NOT EXISTS tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, created TEXT, tracker_url TEXT, branch TEXT, review_url TEXT, commit_template TEXT, notes TEXT, current INTEGER)", []).unwrap();
+    conn.execute("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)", []).unwrap();
+    conn.execute("CREATE TABLE IF NOT EXISTS work_log (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER, start_time TEXT)", []).unwrap();
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM tasks", [], |r| r.get(0)).unwrap();
+    if count == 0 {
+        let now = Local::now().to_rfc3339();
+        conn.execute("INSERT INTO tasks (title, created, tracker_url, branch, review_url, commit_template, notes, current) VALUES (?,?,?,?,?,?,?,0)",
+            params!["Sample Task", now, "", "", "", "", "",]).unwrap();
+    }
+}
+
+fn get_sort_order(conn: &Connection) -> i32 {
+    conn.query_row("SELECT value FROM settings WHERE key='sort_order'", [], |r| r.get::<_, String>(0)).ok()
+        .and_then(|v| v.parse().ok()).unwrap_or(0)
+}
+
+fn save_sort_order(conn: &Connection, order: i32) {
+    conn.execute("INSERT INTO settings(key,value) VALUES('sort_order', ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value", params![order]).unwrap();
+}
+
+fn load_tasks(conn: &Connection, order: i32) -> Vec<TaskData> {
+    let sql = if order == 0 {
+        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY title"
+    } else {
+        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY created"
+    };
+    let mut stmt = conn.prepare(sql).unwrap();
+    let rows = stmt.query_map([], |row| Ok(TaskData {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        created: row.get(2)?,
+        tracker: row.get(3)?,
+        branch: row.get(4)?,
+        review: row.get(5)?,
+        commit: row.get(6)?,
+        notes: row.get(7)?,
+        current: row.get::<_, i64>(8)? != 0,
+    })).unwrap();
+    let mut vec = Vec::new();
+    for r in rows { vec.push(r.unwrap()); }
+    vec
+}
+
+fn load_task_detail(conn: &Connection, id: i64) -> TaskData {
+    conn.query_row("SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks WHERE id=?", params![id], |row| {
+        Ok(TaskData {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            created: row.get(2)?,
+            tracker: row.get(3)?,
+            branch: row.get(4)?,
+            review: row.get(5)?,
+            commit: row.get(6)?,
+            notes: row.get(7)?,
+            current: row.get::<_, i64>(8)? != 0,
+        })
+    }).unwrap()
+}
+
+fn main() {
+    let db_path = "tasks.db".to_string();
+    let conn = Rc::new(Connection::open(&db_path).unwrap());
+    init_db(&conn);
+    let sort_order = get_sort_order(&conn);
+    let tasks_vec = load_tasks(&conn, sort_order);
+    let model = Rc::new(VecModel::from(
+        tasks_vec.iter().map(|t| Task { id: t.id as i32, title: t.title.clone().into(), current: t.current }).collect::<Vec<_>>()
+    ));
+    let app = MainWindow::new().unwrap();
+    app.set_tasks(ModelRc::new(model.clone()));
+    app.set_sort_order(sort_order);
+
+    let task_data = Rc::new(RefCell::new(tasks_vec));
+
+    {
+        let conn = conn.clone();
+        let model = model.clone();
+        let task_data = task_data.clone();
+        app.on_sort_changed(move |order| {
+            save_sort_order(&conn, order);
+            let tasks = load_tasks(&conn, order);
+            model.set_vec(tasks.iter().map(|t| Task { id: t.id as i32, title: t.title.clone().into(), current: t.current }).collect::<Vec<_>>());
+            *task_data.borrow_mut() = tasks;
+        });
+    }
+
+    {
+        let app_weak = app.as_weak();
+        let db_path = db_path.clone();
+        let task_data = task_data.clone();
+        app.on_select_task(move |idx| {
+            if idx < 0 { return; }
+            let task = task_data.borrow()[idx as usize].clone();
+            let app_weak2 = app_weak.clone();
+            let show_loader = Arc::new(AtomicBool::new(true));
+            slint::Timer::single_shot(std::time::Duration::from_millis(100), {
+                let app_weak = app_weak2.clone();
+                let show_loader = show_loader.clone();
+                move || {
+                    if show_loader.load(Ordering::Relaxed) {
+                        if let Some(app) = app_weak.upgrade() {
+                            app.set_loading(true);
+                        }
+                    }
+                }
+            });
+            let db_path2 = db_path.clone();
+            let show_loader2 = show_loader.clone();
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                let thread_conn = Connection::open(&db_path2).unwrap();
+                let detail = load_task_detail(&thread_conn, task.id);
+                show_loader2.store(false, Ordering::Relaxed);
+                slint::invoke_from_event_loop(move || {
+                    if let Some(app) = app_weak2.upgrade() {
+                        app.set_loading(false);
+                        app.set_detail_title(detail.title.into());
+                        app.set_detail_created(detail.created.into());
+                        app.set_detail_tracker(detail.tracker.into());
+                        app.set_detail_branch(detail.branch.into());
+                        app.set_detail_review(detail.review.into());
+                        app.set_detail_commit(detail.commit.into());
+                        app.set_detail_notes(detail.notes.into());
+                    }
+                }).unwrap();
+            });
+        });
+    }
+
+    {
+        let app_weak = app.as_weak();
+        let conn = conn.clone();
+        let task_data = task_data.clone();
+        let model = model.clone();
+        app.on_save_detail(move || {
+            if let Some(app) = app_weak.upgrade() {
+                let idx = app.get_selected_index();
+                if idx >= 0 {
+                    let id = task_data.borrow()[idx as usize].id;
+                    let title = app.get_detail_title().to_string();
+                    let tracker = app.get_detail_tracker().to_string();
+                    let branch = app.get_detail_branch().to_string();
+                    let review = app.get_detail_review().to_string();
+                    let commit = app.get_detail_commit().to_string();
+                    let notes = app.get_detail_notes().to_string();
+                    conn.execute("UPDATE tasks SET title=?, tracker_url=?, branch=?, review_url=?, commit_template=?, notes=? WHERE id=?",
+                        params![title, tracker, branch, review, commit, notes, id]).unwrap();
+                    {
+                        let mut data = task_data.borrow_mut();
+                        let t = &mut data[idx as usize];
+                        t.title = title.clone();
+                        t.tracker = tracker;
+                        t.branch = branch;
+                        t.review = review;
+                        t.commit = commit;
+                        t.notes = notes;
+                        model.set_row_data(idx as usize, Task { id: id as i32, title: t.title.clone().into(), current: t.current });
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        let app_weak = app.as_weak();
+        let conn = conn.clone();
+        let task_data = task_data.clone();
+        let model = model.clone();
+        app.on_set_current(move || {
+            if let Some(app) = app_weak.upgrade() {
+                let idx = app.get_selected_index();
+                if idx >= 0 {
+                    let id = task_data.borrow()[idx as usize].id;
+                    conn.execute("UPDATE tasks SET current=0", []).unwrap();
+                    conn.execute("UPDATE tasks SET current=1 WHERE id=?", params![id]).unwrap();
+                    let now = Local::now().to_rfc3339();
+                    conn.execute("INSERT INTO work_log(task_id,start_time) VALUES(?,?)", params![id, now]).unwrap();
+                    for (i, t) in task_data.borrow_mut().iter_mut().enumerate() {
+                        t.current = t.id == id;
+                        model.set_row_data(i, Task { id: t.id as i32, title: t.title.clone().into(), current: t.current });
+                    }
+                }
+            }
+        });
+    }
+
+    {
+        app.on_about(|| {
+            let about = AboutWindow::new().unwrap();
+            let _ = about.run();
+        });
+    }
+
+    app.set_selected_index(-1);
+    app.run().unwrap();
+}
+

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -1,0 +1,101 @@
+import { LineEdit, TextEdit, Button } from "std-widgets.slint";
+
+export struct Task {
+    id: int,
+    title: string,
+    current: bool,
+}
+
+export component AboutWindow inherits Window {
+    width: 300px;
+    height: 200px;
+    title: "About";
+    VerticalLayout {
+        spacing: 10px;
+        alignment: center;
+        Image { source: @image-url("../assets/slint-logo.png"); }
+        Text { text: "Task Manager"; }
+    }
+}
+
+export component MainWindow inherits Window {
+    preferred-width: 800px;
+    preferred-height: 600px;
+    min-width: 600px;
+    min-height: 400px;
+    title: "Task Manager";
+
+    callback about();
+    callback save_detail();
+    callback set_current();
+    callback select_task(int);
+    callback sort_changed(int);
+
+    in-out property <int> sort_order;
+    // 0 = title, 1 = date
+
+    in-out property <int> selected_index;
+    in property <[Task]> tasks;
+
+    in-out property <bool> loading;
+
+    in-out property <string> detail_title;
+    in-out property <string> detail_created;
+    in-out property <string> detail_tracker;
+    in-out property <string> detail_branch;
+    in-out property <string> detail_review;
+    in-out property <string> detail_commit;
+    in-out property <string> detail_notes;
+
+    VerticalLayout {
+        spacing: 4px;
+        HorizontalLayout {
+            spacing: 4px;
+            Text { text: "Sort:"; vertical-alignment: center; }
+            Button { text: "Title"; clicked => { root.sort_order = 0; root.sort_changed(0); } }
+            Button { text: "Date"; clicked => { root.sort_order = 1; root.sort_changed(1); } }
+            Rectangle { horizontal-stretch: 1; }
+            Button { text: "About"; clicked => { root.about(); } }
+        }
+        HorizontalLayout {
+            spacing: 10px;
+            VerticalLayout {
+                width: 200px;
+                for task[i] in tasks: Rectangle {
+                    width: 200px;
+                    height: 30px;
+                    background: task.current ? #e0f0ff : #ffffff;
+                    Text { text: task.title; y: 4px; x: 4px; }
+                    TouchArea { clicked => { root.selected_index = i; root.select_task(i); } }
+                }
+            }
+            Flickable {
+                vertical-stretch: 1;
+    VerticalLayout {
+                    spacing: 8px;
+                    Text { text: "Title"; }
+                    LineEdit { text: root.detail_title; }
+                    Text { text: "Created"; }
+                    LineEdit { enabled: false; text: root.detail_created; }
+                    Text { text: "Tracker"; }
+                    LineEdit { text: root.detail_tracker; }
+                    Text { text: "Branch"; }
+                    LineEdit { text: root.detail_branch; }
+                    Text { text: "Review"; }
+                    LineEdit { text: root.detail_review; }
+                    Text { text: "Commit"; }
+                    TextEdit { height: 60px; text: root.detail_commit; }
+                    Text { text: "Notes"; }
+                    TextEdit { height: 120px; text: root.detail_notes; }
+                    HorizontalLayout {
+                        spacing: 8px;
+                        Button { text: "Save"; clicked => root.save_detail(); }
+                        Button { text: "Set Current"; clicked => root.set_current(); }
+                    }
+                    Text { text: "Loading..."; visible: root.loading; }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- drop `Cargo.lock` from version control
- rebuild Slint UI with button toolbar and callbacks for sorting, selection, and About dialog
- refactor Rust backend to use shared SQLite connection and async detail loading

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68c6f2cf0850832893f3a3795283f66f