### PR TITLE
Revamp UI and add task creation flow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
-use slint::{ComponentHandle, ModelRc, VecModel, Model};
-use rusqlite::{Connection, params};
-use chrono::Local;
-use std::{rc::Rc, cell::RefCell};
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use chrono::{DateTime, Local};
+use rusqlite::{params, Connection};
+use slint::{ComponentHandle, Model, ModelRc, VecModel};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::{cell::RefCell, rc::Rc};
 
 slint::include_modules!();
 
@@ -21,9 +24,15 @@ struct TaskData {
 
 fn init_db(conn: &Connection) {
     conn.execute("CREATE TABLE IF NOT EXISTS tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, created TEXT, tracker_url TEXT, branch TEXT, review_url TEXT, commit_template TEXT, notes TEXT, current INTEGER)", []).unwrap();
-    conn.execute("CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)", []).unwrap();
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+        [],
+    )
+    .unwrap();
     conn.execute("CREATE TABLE IF NOT EXISTS work_log (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER, start_time TEXT)", []).unwrap();
-    let count: i64 = conn.query_row("SELECT COUNT(*) FROM tasks", [], |r| r.get(0)).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM tasks", [], |r| r.get(0))
+        .unwrap();
     if count == 0 {
         let now = Local::now().to_rfc3339();
         conn.execute("INSERT INTO tasks (title, created, tracker_url, branch, review_url, commit_template, notes, current) VALUES (?,?,?,?,?,?,?,0)",
@@ -32,8 +41,14 @@ fn init_db(conn: &Connection) {
 }
 
 fn get_sort_order(conn: &Connection) -> i32 {
-    conn.query_row("SELECT value FROM settings WHERE key='sort_order'", [], |r| r.get::<_, String>(0)).ok()
-        .and_then(|v| v.parse().ok()).unwrap_or(0)
+    conn.query_row(
+        "SELECT value FROM settings WHERE key='sort_order'",
+        [],
+        |r| r.get::<_, String>(0),
+    )
+    .ok()
+    .and_then(|v| v.parse().ok())
+    .unwrap_or(0)
 }
 
 fn save_sort_order(conn: &Connection, order: i32) {
@@ -42,24 +57,30 @@ fn save_sort_order(conn: &Connection, order: i32) {
 
 fn load_tasks(conn: &Connection, order: i32) -> Vec<TaskData> {
     let sql = if order == 0 {
-        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY title"
+        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY title COLLATE NOCASE"
     } else {
-        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY created"
+        "SELECT id,title,created,tracker_url,branch,review_url,commit_template,notes,current FROM tasks ORDER BY datetime(created) DESC"
     };
     let mut stmt = conn.prepare(sql).unwrap();
-    let rows = stmt.query_map([], |row| Ok(TaskData {
-        id: row.get(0)?,
-        title: row.get(1)?,
-        created: row.get(2)?,
-        tracker: row.get(3)?,
-        branch: row.get(4)?,
-        review: row.get(5)?,
-        commit: row.get(6)?,
-        notes: row.get(7)?,
-        current: row.get::<_, i64>(8)? != 0,
-    })).unwrap();
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(TaskData {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                created: row.get(2)?,
+                tracker: row.get(3)?,
+                branch: row.get(4)?,
+                review: row.get(5)?,
+                commit: row.get(6)?,
+                notes: row.get(7)?,
+                current: row.get::<_, i64>(8)? != 0,
+            })
+        })
+        .unwrap();
     let mut vec = Vec::new();
-    for r in rows { vec.push(r.unwrap()); }
+    for r in rows {
+        vec.push(r.unwrap());
+    }
     vec
 }
 
@@ -79,6 +100,38 @@ fn load_task_detail(conn: &Connection, id: i64) -> TaskData {
     }).unwrap()
 }
 
+fn format_timestamp(value: &str) -> String {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| {
+            dt.with_timezone(&Local)
+                .format("%Y-%m-%d %H:%M")
+                .to_string()
+        })
+        .unwrap_or_else(|_| value.to_string())
+}
+
+fn apply_task_to_ui(app: &MainWindow, detail: &TaskData) {
+    app.set_loading(false);
+    app.set_detail_title(detail.title.clone().into());
+    app.set_detail_created(format_timestamp(&detail.created).into());
+    app.set_detail_tracker(detail.tracker.clone().into());
+    app.set_detail_branch(detail.branch.clone().into());
+    app.set_detail_review(detail.review.clone().into());
+    app.set_detail_commit(detail.commit.clone().into());
+    app.set_detail_notes(detail.notes.clone().into());
+}
+
+fn clear_task_detail(app: &MainWindow) {
+    app.set_loading(false);
+    app.set_detail_title("".into());
+    app.set_detail_created("".into());
+    app.set_detail_tracker("".into());
+    app.set_detail_branch("".into());
+    app.set_detail_review("".into());
+    app.set_detail_commit("".into());
+    app.set_detail_notes("".into());
+}
+
 fn main() {
     let db_path = "tasks.db".to_string();
     let conn = Rc::new(Connection::open(&db_path).unwrap());
@@ -86,11 +139,22 @@ fn main() {
     let sort_order = get_sort_order(&conn);
     let tasks_vec = load_tasks(&conn, sort_order);
     let model = Rc::new(VecModel::from(
-        tasks_vec.iter().map(|t| Task { id: t.id as i32, title: t.title.clone().into(), current: t.current }).collect::<Vec<_>>()
+        tasks_vec
+            .iter()
+            .map(|t| Task {
+                id: t.id as i32,
+                title: t.title.clone().into(),
+                current: t.current,
+            })
+            .collect::<Vec<_>>(),
     ));
     let app = MainWindow::new().unwrap();
     app.set_tasks(ModelRc::new(model.clone()));
     app.set_sort_order(sort_order);
+    app.set_new_task_title("".into());
+    app.set_loading(false);
+    app.set_has_tasks(!tasks_vec.is_empty());
+    clear_task_detail(&app);
 
     let task_data = Rc::new(RefCell::new(tasks_vec));
 
@@ -98,11 +162,53 @@ fn main() {
         let conn = conn.clone();
         let model = model.clone();
         let task_data = task_data.clone();
+        let app_weak = app.as_weak();
         app.on_sort_changed(move |order| {
             save_sort_order(&conn, order);
+
+            let (selected_id, had_selection) = app_weak
+                .upgrade()
+                .map(|app| {
+                    let idx = app.get_selected_index();
+                    if idx >= 0 {
+                        let id = task_data.borrow().get(idx as usize).map(|t| t.id);
+                        (id, true)
+                    } else {
+                        (None, false)
+                    }
+                })
+                .unwrap_or((None, false));
+
             let tasks = load_tasks(&conn, order);
-            model.set_vec(tasks.iter().map(|t| Task { id: t.id as i32, title: t.title.clone().into(), current: t.current }).collect::<Vec<_>>());
-            *task_data.borrow_mut() = tasks;
+            model.set_vec(
+                tasks
+                    .iter()
+                    .map(|t| Task {
+                        id: t.id as i32,
+                        title: t.title.clone().into(),
+                        current: t.current,
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            *task_data.borrow_mut() = tasks.clone();
+
+            if let Some(app) = app_weak.upgrade() {
+                app.set_has_tasks(!tasks.is_empty());
+                if let Some(id) = selected_id {
+                    if let Some(new_index) = tasks.iter().position(|t| t.id == id) {
+                        app.set_selected_index(new_index as i32);
+                        apply_task_to_ui(&app, &tasks[new_index]);
+                    } else {
+                        app.set_selected_index(-1);
+                        clear_task_detail(&app);
+                    }
+                } else if had_selection {
+                    app.set_selected_index(-1);
+                    clear_task_detail(&app);
+                } else {
+                    clear_task_detail(&app);
+                }
+            }
         });
     }
 
@@ -111,7 +217,17 @@ fn main() {
         let db_path = db_path.clone();
         let task_data = task_data.clone();
         app.on_select_task(move |idx| {
-            if idx < 0 { return; }
+            if idx < 0 {
+                if let Some(app) = app_weak.upgrade() {
+                    app.set_loading(false);
+                    clear_task_detail(&app);
+                }
+                return;
+            }
+            let idx_usize = idx as usize;
+            if idx_usize >= task_data.borrow().len() {
+                return;
+            }
             let task = task_data.borrow()[idx as usize].clone();
             let app_weak2 = app_weak.clone();
             let show_loader = Arc::new(AtomicBool::new(true));
@@ -136,15 +252,10 @@ fn main() {
                 slint::invoke_from_event_loop(move || {
                     if let Some(app) = app_weak2.upgrade() {
                         app.set_loading(false);
-                        app.set_detail_title(detail.title.into());
-                        app.set_detail_created(detail.created.into());
-                        app.set_detail_tracker(detail.tracker.into());
-                        app.set_detail_branch(detail.branch.into());
-                        app.set_detail_review(detail.review.into());
-                        app.set_detail_commit(detail.commit.into());
-                        app.set_detail_notes(detail.notes.into());
+                        apply_task_to_ui(&app, &detail);
                     }
-                }).unwrap();
+                })
+                .unwrap();
             });
         });
     }
@@ -177,6 +288,7 @@ fn main() {
                         t.commit = commit;
                         t.notes = notes;
                         model.set_row_data(idx as usize, Task { id: id as i32, title: t.title.clone().into(), current: t.current });
+                        apply_task_to_ui(&app, t);
                     }
                 }
             }
@@ -194,13 +306,61 @@ fn main() {
                 if idx >= 0 {
                     let id = task_data.borrow()[idx as usize].id;
                     conn.execute("UPDATE tasks SET current=0", []).unwrap();
-                    conn.execute("UPDATE tasks SET current=1 WHERE id=?", params![id]).unwrap();
+                    conn.execute("UPDATE tasks SET current=1 WHERE id=?", params![id])
+                        .unwrap();
                     let now = Local::now().to_rfc3339();
-                    conn.execute("INSERT INTO work_log(task_id,start_time) VALUES(?,?)", params![id, now]).unwrap();
+                    conn.execute(
+                        "INSERT INTO work_log(task_id,start_time) VALUES(?,?)",
+                        params![id, now],
+                    )
+                    .unwrap();
                     for (i, t) in task_data.borrow_mut().iter_mut().enumerate() {
                         t.current = t.id == id;
-                        model.set_row_data(i, Task { id: t.id as i32, title: t.title.clone().into(), current: t.current });
+                        model.set_row_data(
+                            i,
+                            Task {
+                                id: t.id as i32,
+                                title: t.title.clone().into(),
+                                current: t.current,
+                            },
+                        );
                     }
+                }
+            }
+        });
+    }
+
+    {
+        let app_weak = app.as_weak();
+        let conn = conn.clone();
+        let model = model.clone();
+        let task_data = task_data.clone();
+        app.on_add_task(move |title| {
+            let trimmed = title.trim();
+            if trimmed.is_empty() {
+                if let Some(app) = app_weak.upgrade() {
+                    app.set_new_task_title("".into());
+                }
+                return;
+            }
+            let now = Local::now().to_rfc3339();
+            conn.execute("INSERT INTO tasks (title, created, tracker_url, branch, review_url, commit_template, notes, current) VALUES (?,?,?,?,?,?,?,0)",
+                params![trimmed, now, "", "", "", "", ""]).unwrap();
+            let id = conn.last_insert_rowid();
+            let order = app_weak.upgrade().map(|app| app.get_sort_order()).unwrap_or(0);
+            let tasks = load_tasks(&conn, order);
+            model.set_vec(tasks.iter().map(|t| Task { id: t.id as i32, title: t.title.clone().into(), current: t.current }).collect::<Vec<_>>());
+            *task_data.borrow_mut() = tasks.clone();
+
+            if let Some(app) = app_weak.upgrade() {
+                app.set_new_task_title("".into());
+                app.set_has_tasks(!tasks.is_empty());
+                if let Some(index) = tasks.iter().position(|t| t.id == id) {
+                    app.set_selected_index(index as i32);
+                    apply_task_to_ui(&app, &tasks[index]);
+                } else {
+                    app.set_selected_index(-1);
+                    clear_task_detail(&app);
                 }
             }
         });
@@ -216,4 +376,3 @@ fn main() {
     app.set_selected_index(-1);
     app.run().unwrap();
 }
-

--- a/ui/main.slint
+++ b/ui/main.slint
@@ -18,18 +18,62 @@ export component AboutWindow inherits Window {
     }
 }
 
+component TaskListItem inherits Rectangle {
+    in property <int> index;
+    in property <string> title;
+    in property <bool> selected;
+    in property <bool> current;
+    callback activate(int);
+
+    height: 48px;
+    border-radius: 12px;
+    border-width: selected ? 1px : 0px;
+    border-color: #3b82f6;
+    background: selected ? #eef2ff : (current ? #f0f9ff : #ffffff);
+
+    HorizontalLayout {
+        padding: 12px;
+        spacing: 8px;
+        vertical-stretch: 1;
+        Text {
+            text: title;
+            horizontal-stretch: 1;
+            vertical-alignment: center;
+            color: #1f2937;
+            font-size: 14px;
+        }
+        Rectangle {
+            visible: current;
+            border-radius: 8px;
+            background: #dbeafe;
+            HorizontalLayout {
+                padding: 4px;
+                Text {
+                    text: "CURRENT";
+                    color: #1d4ed8;
+                    font-size: 11px;
+                    vertical-alignment: center;
+                }
+            }
+        }
+    }
+    TouchArea { clicked => root.activate(root.index); }
+}
+
 export component MainWindow inherits Window {
-    preferred-width: 800px;
-    preferred-height: 600px;
-    min-width: 600px;
-    min-height: 400px;
+    preferred-width: 900px;
+    preferred-height: 620px;
+    min-width: 640px;
+    min-height: 420px;
     title: "Task Manager";
+    background: #f4f6fb;
 
     callback about();
     callback save_detail();
     callback set_current();
     callback select_task(int);
     callback sort_changed(int);
+    callback add_task(string);
 
     in-out property <int> sort_order;
     // 0 = title, 1 = date
@@ -38,6 +82,7 @@ export component MainWindow inherits Window {
     in property <[Task]> tasks;
 
     in-out property <bool> loading;
+    in-out property <bool> has_tasks;
 
     in-out property <string> detail_title;
     in-out property <string> detail_created;
@@ -46,53 +91,177 @@ export component MainWindow inherits Window {
     in-out property <string> detail_review;
     in-out property <string> detail_commit;
     in-out property <string> detail_notes;
+    in-out property <string> new_task_title;
 
     VerticalLayout {
-        spacing: 4px;
-        HorizontalLayout {
-            spacing: 4px;
-            Text { text: "Sort:"; vertical-alignment: center; }
-            Button { text: "Title"; clicked => { root.sort_order = 0; root.sort_changed(0); } }
-            Button { text: "Date"; clicked => { root.sort_order = 1; root.sort_changed(1); } }
-            Rectangle { horizontal-stretch: 1; }
-            Button { text: "About"; clicked => { root.about(); } }
-        }
-        HorizontalLayout {
-            spacing: 10px;
-            VerticalLayout {
-                width: 200px;
-                for task[i] in tasks: Rectangle {
-                    width: 200px;
-                    height: 30px;
-                    background: task.current ? #e0f0ff : #ffffff;
-                    Text { text: task.title; y: 4px; x: 4px; }
-                    TouchArea { clicked => { root.selected_index = i; root.select_task(i); } }
+        spacing: 16px;
+        padding: 20px;
+
+        Rectangle {
+            height: 76px;
+            border-radius: 18px;
+            background: #0f172a;
+            HorizontalLayout {
+                padding: 20px;
+                spacing: 14px;
+                Text {
+                    text: "Task Manager";
+                    color: #ffffff;
+                    font-size: 24px;
+                    horizontal-stretch: 1;
+                    vertical-alignment: center;
+                }
+                HorizontalLayout {
+                    spacing: 8px;
+                    Text {
+                        text: "Sort by:";
+                        color: #cbd5f5;
+                        vertical-alignment: center;
+                    }
+                    Button {
+                        text: root.sort_order == 0 ? "Title ✓" : "Title";
+                        clicked => { root.sort_order = 0; root.sort_changed(0); }
+                    }
+                    Button {
+                        text: root.sort_order == 1 ? "Created ✓" : "Created";
+                        clicked => { root.sort_order = 1; root.sort_changed(1); }
+                    }
+                }
+                Button {
+                    text: "About";
+                    clicked => { root.about(); }
                 }
             }
-            Flickable {
-                vertical-stretch: 1;
-    VerticalLayout {
-                    spacing: 8px;
-                    Text { text: "Title"; }
-                    LineEdit { text: root.detail_title; }
-                    Text { text: "Created"; }
-                    LineEdit { enabled: false; text: root.detail_created; }
-                    Text { text: "Tracker"; }
-                    LineEdit { text: root.detail_tracker; }
-                    Text { text: "Branch"; }
-                    LineEdit { text: root.detail_branch; }
-                    Text { text: "Review"; }
-                    LineEdit { text: root.detail_review; }
-                    Text { text: "Commit"; }
-                    TextEdit { height: 60px; text: root.detail_commit; }
-                    Text { text: "Notes"; }
-                    TextEdit { height: 120px; text: root.detail_notes; }
-                    HorizontalLayout {
-                        spacing: 8px;
-                        Button { text: "Save"; clicked => root.save_detail(); }
-                        Button { text: "Set Current"; clicked => root.set_current(); }
+        }
+
+        HorizontalLayout {
+            spacing: 20px;
+            vertical-stretch: 1;
+
+            Rectangle {
+                preferred-width: 260px;
+                min-width: 220px;
+                border-radius: 16px;
+                border-color: #d9e0ec;
+                border-width: 1px;
+                background: #ffffff;
+
+                VerticalLayout {
+                    padding: 16px;
+                    spacing: 12px;
+                    Text {
+                        text: "Tasks";
+                        font-size: 18px;
+                        color: #0f172a;
                     }
-                    Text { text: "Loading..."; visible: root.loading; }
+                    Rectangle { height: 1px; background: #e5e7eb; }
+                    if !root.has_tasks : Text {
+                        text: "No tasks yet.\nCreate one to get started.";
+                        color: #6b7280;
+                    }
+                    Flickable {
+                        vertical-stretch: 1;
+                        VerticalLayout {
+                            spacing: 8px;
+                            for task[i] in tasks: TaskListItem {
+                                index: i;
+                                title: task.title;
+                                current: task.current;
+                                selected: root.selected_index == i;
+                                activate => {
+                                    root.selected_index = i;
+                                    root.select_task(i);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Rectangle {
+                horizontal-stretch: 1;
+                border-radius: 16px;
+                border-color: #d9e0ec;
+                border-width: 1px;
+                background: #ffffff;
+
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 16px;
+
+                    Text {
+                        text: "Create a new task";
+                        font-size: 16px;
+                        color: #0f172a;
+                    }
+                    HorizontalLayout {
+                        spacing: 10px;
+                        LineEdit {
+                            text <=> root.new_task_title;
+                            placeholder-text: "Task title";
+                            horizontal-stretch: 1;
+                        }
+                        Button {
+                            text: "Add Task";
+                            enabled: root.new_task_title != "";
+                            clicked => { root.add_task(root.new_task_title); }
+                        }
+                    }
+                    Rectangle { height: 1px; background: #e5e7eb; }
+
+                    Text {
+                        text: "Task details";
+                        font-size: 16px;
+                        color: #0f172a;
+                    }
+                    Text {
+                        text: "Select a task from the list\nto view and edit its details.";
+                        visible: root.selected_index < 0;
+                        color: #6b7280;
+                    }
+
+                    Flickable {
+                        vertical-stretch: 1;
+
+                        VerticalLayout {
+                            spacing: 10px;
+                            visible: root.selected_index >= 0;
+
+                            Text { text: "Title"; }
+                            LineEdit { text <=> root.detail_title; enabled: !root.loading; }
+
+                            Text { text: "Created"; }
+                            LineEdit { enabled: false; text <=> root.detail_created; }
+
+                            Text { text: "Tracker"; }
+                            LineEdit { text <=> root.detail_tracker; enabled: !root.loading; }
+
+                            Text { text: "Branch"; }
+                            LineEdit { text <=> root.detail_branch; enabled: !root.loading; }
+
+                            Text { text: "Review"; }
+                            LineEdit { text <=> root.detail_review; enabled: !root.loading; }
+
+                            Text { text: "Commit"; }
+                            TextEdit { height: 80px; text <=> root.detail_commit; enabled: !root.loading; }
+
+                            Text { text: "Notes"; }
+                            TextEdit { height: 140px; text <=> root.detail_notes; enabled: !root.loading; }
+
+                            HorizontalLayout {
+                                spacing: 12px;
+                                Button { text: "Save"; clicked => root.save_detail(); enabled: !root.loading; }
+                                Button { text: "Set Current"; clicked => root.set_current(); enabled: !root.loading; }
+                            }
+                        }
+                    }
+
+                    Text {
+                        text: "Loading task details...";
+                        visible: root.loading;
+                        color: #2563eb;
+                        font-size: 12px;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- redesign the main window with a richer task list, creation form, and contextual messaging
- add logic to create tasks, refresh detail bindings, format timestamps, and expose new UI state
- retain the original bundled logo asset so no PNG changes ship with the UI updates

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c90f5e86ac832894f6496587ffb103