### PR TITLE
Add roadmap document and revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-[demo.webm](demo.webm)
+# Rust Slint Task Manager
+
+A desktop task manager built with [Slint](https://slint.dev/) and Rust. The application stores tasks locally in an SQLite database and provides a compact dashboard to review task metadata, edit details, and mark the item you are currently working on. A lightweight work-log table captures when a task is marked as current, laying the groundwork for future reporting.
+
+[View the demo video](demo.webm)
+
+## Features
+
+- **Task overview:** Browse all saved tasks, sort by title or creation date, and keep a single "current" task highlighted in the list.
+- **Editable detail pane:** Update tracker links, branches, review URLs, commit message templates, and free-form notes.
+- **Work focus tracking:** Setting a task as current records a timestamp in the `work_log` table for later analytics.
+- **Responsive UI:** The interface is authored in Slint, giving a modern look-and-feel with loading states while the detail pane fetches data.
+
+## Project Structure
+
+```
+.
+├── src/main.rs        # Application logic, database interactions, Slint callbacks
+├── ui/main.slint      # Declarative UI layout and styling
+├── assets/            # Images used in the UI
+├── build.rs           # Slint build integration
+└── tasks.db           # SQLite database (created at runtime)
+```
+
+## Getting Started
+
+1. **Install dependencies**
+   - Rust toolchain (stable) from [rustup.rs](https://rustup.rs/).
+   - Native dependencies for SQLite (pre-installed on most systems).
+2. **Run the application**
+
+   ```bash
+   cargo run
+   ```
+
+   A `tasks.db` file is created automatically in the project root the first time the application runs.
+
+3. **Resetting the database**
+   - Delete the generated `tasks.db` file to start from a clean slate.
+
+## Roadmap
+
+Curious about where the project is headed next? Check out [ROADMAP.md](ROADMAP.md) for an in-depth look at planned improvements, from foundational polish to long-term strategic ideas.
+
+## Contributing
+
+Contributions are welcome! Feel free to open an issue to discuss ideas or submit a pull request with enhancements. Please accompany changes with context and testing notes to keep the project healthy.
+
+## License
+
+Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,102 @@
 # Rust Slint Task Manager
 
-A desktop task manager built with [Slint](https://slint.dev/) and Rust. The application stores tasks locally in an SQLite database and provides a compact dashboard to review task metadata, edit details, and mark the item you are currently working on. A lightweight work-log table captures when a task is marked as current, laying the groundwork for future reporting.
+A desktop companion for software projects built with [Slint](https://slint.dev/) and Rust. The app keeps your backlog close at hand with a polished native UI, rich metadata for every task, and a lightweight focus log so you can see what you are working on.
 
-[View the demo video](demo.webm)
+<div align="center">
+  <video src="demo.webm" controls style="max-width: 100%; border-radius: 12px;">
+    Your browser does not support the video tag.
+  </video>
+</div>
 
-## Features
+## Overview
 
-- **Task overview:** Browse all saved tasks, sort by title or creation date, and keep a single "current" task highlighted in the list.
-- **Editable detail pane:** Update tracker links, branches, review URLs, commit message templates, and free-form notes.
-- **Work focus tracking:** Setting a task as current records a timestamp in the `work_log` table for later analytics.
-- **Responsive UI:** The interface is authored in Slint, giving a modern look-and-feel with loading states while the detail pane fetches data.
+- **Purpose-built for developers** – Track tracker links, review URLs, branch names, commit templates, and notes without reaching for a spreadsheet.
+- **Fast native experience** – Slint renders a fluid interface that feels at home on Windows, macOS, and Linux.
+- **Local-first storage** – Data lives in a bundled SQLite database so your tasks persist without setting up a backend service.
 
-## Project Structure
+## Feature Highlights
+
+- **Organised task list** – Toggle sorting between title and creation time while keeping the current selection steady.
+- **Detailed editor** – Update metadata inline and see when the task was created in your local timezone.
+- **Current focus tracking** – Mark a task as "current"; every change appends a row to a work log table for future analytics.
+- **Guided empty state** – The first run seeds a sample task so you can explore the interface immediately.
+- **About dialog** – Access a quick app summary from the header for sharing with teammates.
+
+## UI Tour
+
+### 1. Header bar
+A compact banner surfaces the app name, sort toggles, and quick access to the About dialog.
+
+### 2. Task list panel
+Scroll through saved tasks, highlight the active one, and instantly switch between alphabetical or chronological order. Tasks marked as current display a badge to keep them visible.
+
+### 3. Task creation row
+Create new items from the detail side with a single text field and keyboard-friendly button.
+
+### 4. Detail editor
+Review and edit the selected task's metadata, including tracker links, code branches, review URLs, commit message templates, and free-form notes. The panel shows loading states while data is fetched on a background thread.
+
+### 5. Focus controls
+Use the "Set as current" button to log the start time of your focus session in the `work_log` table.
+
+## Data Model
+
+The app creates and maintains three SQLite tables the first time it runs:
+
+| Table | Purpose |
+| ----- | ------- |
+| `tasks` | Stores task metadata (title, timestamps, links, notes, and whether the task is current). |
+| `settings` | Persists the selected sort order across launches. |
+| `work_log` | Records a timestamp whenever a task is marked current to support future reporting. |
+
+`tasks.db` is placed beside the executable. Remove the file to reset the application state.
+
+## Getting Started
+
+### Prerequisites
+
+- [Rust](https://www.rust-lang.org/tools/install) 1.70 or newer
+- No extra system dependencies are required because `rusqlite` is compiled with bundled SQLite.
+
+### Run the application
+
+```bash
+cargo run
+```
+
+A sample task is inserted on first launch so you can try the workflow immediately.
+
+### Build an optimised binary
+
+```bash
+cargo build --release
+```
+
+The optimised executable is available at `target/release/rust-slint` (or with the appropriate platform extension).
+
+## Development Workflow
+
+- `cargo fmt` – Format the Rust sources.
+- `cargo clippy --all-targets --all-features` – Lint the project for common pitfalls.
+- `cargo check` – Type-check the codebase quickly while iterating.
+- (Planned) Add unit and integration tests as outlined in the [roadmap](ROADMAP.md).
+
+## Project Layout
 
 ```
 .
 ├── src/main.rs        # Application logic, database interactions, Slint callbacks
 ├── ui/main.slint      # Declarative UI layout and styling
-├── assets/            # Images used in the UI
-├── build.rs           # Slint build integration
-└── tasks.db           # SQLite database (created at runtime)
+├── assets/            # Static imagery used in the UI (logo, etc.)
+├── build.rs           # Builds the Slint UI module before compilation
+├── demo.webm          # Short screencast of the main workflow
+└── Cargo.toml         # Rust workspace manifest with dependencies
 ```
-
-## Getting Started
-
-1. **Install dependencies**
-   - Rust toolchain (stable) from [rustup.rs](https://rustup.rs/).
-   - Native dependencies for SQLite (pre-installed on most systems).
-2. **Run the application**
-
-   ```bash
-   cargo run
-   ```
-
-   A `tasks.db` file is created automatically in the project root the first time the application runs.
-
-3. **Resetting the database**
-   - Delete the generated `tasks.db` file to start from a clean slate.
 
 ## Roadmap
 
-Curious about where the project is headed next? Check out [ROADMAP.md](ROADMAP.md) for an in-depth look at planned improvements, from foundational polish to long-term strategic ideas.
-
-## Contributing
-
-Contributions are welcome! Feel free to open an issue to discuss ideas or submit a pull request with enhancements. Please accompany changes with context and testing notes to keep the project healthy.
+Curious about what is next? Dive into [ROADMAP.md](ROADMAP.md) for a staged improvement plan covering polish, productivity features, and long-term ambitions.
 
 ## License
 
-Licensed under the [MIT License](LICENSE).
+Distributed under the terms of the [MIT License](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # Roadmap
 
-This roadmap captures a forward-looking plan for the Rust Slint Task Manager. It pairs an honest assessment of the current state with a staged set of improvements designed to make the application a reliable companion for day-to-day development work.
+This roadmap sketches out how the Rust Slint Task Manager can grow from a handy local tracker into a polished productivity companion. It pairs an honest assessment of today with staged initiatives that build confidence, unlock new workflows, and prepare for distribution.
 
 ## Current Assessment
 
 ### Strengths
 - **Solid foundations:** A clear Slint UI and a lightweight SQLite schema already support the core workflow of creating, editing, and focusing on tasks.
-- **Responsive interactions:** The detail pane uses background loading and progress feedback to keep the interface responsive even when the database query is slow.
+- **Responsive interactions:** The detail pane fetches data on a background thread and exposes loading states to keep the interface fluid.
 - **Work-log data model:** Each "set current" action is timestamped, providing data that can later power focus analytics.
 
 ### Key Gaps
@@ -16,10 +16,10 @@ This roadmap captures a forward-looking plan for the Rust Slint Task Manager. It
 - **Testing and modularity:** Application logic sits in `main.rs` without unit tests or modules, making it hard to extend safely.
 
 ## Strategic Themes
-1. **Polish the fundamentals** – improve reliability, validation, and the editing experience.
-2. **Unlock productivity features** – add planning aids such as prioritisation, reminders, and quick navigation.
-3. **Leverage collected data** – transform the existing work-log entries into insights and reporting.
-4. **Prepare for distribution** – package the app so contributors and teammates can try it without a Rust toolchain.
+1. **Polish the fundamentals** – Improve reliability, validation, and the editing experience.
+2. **Unlock productivity features** – Add planning aids such as prioritisation, reminders, and quick navigation.
+3. **Leverage collected data** – Transform the existing work-log entries into insights and reporting.
+4. **Prepare for distribution** – Package the app so contributors and teammates can try it without a Rust toolchain.
 
 ## Near-Term Goals (v0.2 – Foundations)
 - Introduce structured error handling (`anyhow`, `thiserror`) and surface failures to the UI.
@@ -43,11 +43,11 @@ This roadmap captures a forward-looking plan for the Rust Slint Task Manager. It
 - Offer extension hooks (command palette, plugin interface) so advanced users can script custom workflows.
 
 ## Technical Improvement Backlog
-- **Refactor UI bindings:** Replace manual property synchronization with view-model structs to reduce boilerplate and keep logic testable.
+- **Refactor UI bindings:** Replace manual property synchronisation with view-model structs to reduce boilerplate and keep logic testable.
 - **Performance profiling:** Benchmark load times for large task lists and add pagination or incremental loading if required.
 - **Accessibility:** Audit contrast ratios, provide larger text presets, and add keyboard focus indicators to meet accessibility guidelines.
 - **Localization:** Externalise user-facing strings and add language selection support.
-- **Documentation:** Expand README with architecture diagrams and contribute setup instructions for contributors on each platform.
+- **Documentation:** Expand README with architecture diagrams and contributor setup instructions for each platform.
 
 ## Measuring Success
 - Track adoption metrics such as the number of tasks created, retention of the `current` marker, and the frequency of work-log usage (via opt-in telemetry or manual reporting).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# Roadmap
+
+This roadmap captures a forward-looking plan for the Rust Slint Task Manager. It pairs an honest assessment of the current state with a staged set of improvements designed to make the application a reliable companion for day-to-day development work.
+
+## Current Assessment
+
+### Strengths
+- **Solid foundations:** A clear Slint UI and a lightweight SQLite schema already support the core workflow of creating, editing, and focusing on tasks.
+- **Responsive interactions:** The detail pane uses background loading and progress feedback to keep the interface responsive even when the database query is slow.
+- **Work-log data model:** Each "set current" action is timestamped, providing data that can later power focus analytics.
+
+### Key Gaps
+- **Limited task metadata:** There are no due dates, priorities, tags, or status values to help users triage work.
+- **Minimal workflow support:** Users cannot search, filter, bulk-edit, or archive tasks; the work log is collected but never surfaced to the user.
+- **Error handling and resilience:** Database access assumes success, the `tasks.db` file lives beside the binary with no backup, and the UI does not surface failures.
+- **Testing and modularity:** Application logic sits in `main.rs` without unit tests or modules, making it hard to extend safely.
+
+## Strategic Themes
+1. **Polish the fundamentals** – improve reliability, validation, and the editing experience.
+2. **Unlock productivity features** – add planning aids such as prioritisation, reminders, and quick navigation.
+3. **Leverage collected data** – transform the existing work-log entries into insights and reporting.
+4. **Prepare for distribution** – package the app so contributors and teammates can try it without a Rust toolchain.
+
+## Near-Term Goals (v0.2 – Foundations)
+- Introduce structured error handling (`anyhow`, `thiserror`) and surface failures to the UI.
+- Split database code into a `storage` module with repository-style functions plus integration tests using temporary SQLite files.
+- Replace the unconditional sample task seeding with a guided empty state inside the UI.
+- Add validation to prevent duplicate titles and to normalise URLs before saving.
+- Ensure `cargo fmt`, `cargo clippy`, and basic unit tests run in CI (GitHub Actions or similar).
+
+## Mid-Term Goals (v0.3 – Productivity Boost)
+- Extend the schema with optional fields: priority (enum), due date (`datetime`), status (`active`, `blocked`, `done`), and free-form tags stored in a join table.
+- Implement search, filters, and sort toggles in the UI to help users find tasks quickly.
+- Allow bulk operations (archive, delete) and add soft-deletion support so the database never loses history instantly.
+- Add a work-log viewer that summarises daily/weekly focus time per task and allows exporting CSV.
+- Introduce keyboard shortcuts (e.g., `Cmd/Ctrl+N` to add a task, arrow keys to navigate the list).
+
+## Long-Term Vision (v0.4+)
+- Package the app for Windows, macOS, and Linux using cross-platform bundlers (e.g., `cargo bundle`, `tauri-bundler`, or platform-specific tooling).
+- Support optional cloud sync by abstracting the storage layer and adding a remote backend (e.g., REST or gRPC service).
+- Enable integrations with popular issue trackers (Jira, GitHub) by storing authentication tokens securely and syncing metadata.
+- Provide configurable notifications and reminders, leveraging the operating system notification APIs.
+- Offer extension hooks (command palette, plugin interface) so advanced users can script custom workflows.
+
+## Technical Improvement Backlog
+- **Refactor UI bindings:** Replace manual property synchronization with view-model structs to reduce boilerplate and keep logic testable.
+- **Performance profiling:** Benchmark load times for large task lists and add pagination or incremental loading if required.
+- **Accessibility:** Audit contrast ratios, provide larger text presets, and add keyboard focus indicators to meet accessibility guidelines.
+- **Localization:** Externalise user-facing strings and add language selection support.
+- **Documentation:** Expand README with architecture diagrams and contribute setup instructions for contributors on each platform.
+
+## Measuring Success
+- Track adoption metrics such as the number of tasks created, retention of the `current` marker, and the frequency of work-log usage (via opt-in telemetry or manual reporting).
+- Define performance targets (e.g., initial load under 200 ms for 500 tasks) and automate regression detection in CI.
+- Gather qualitative feedback through GitHub Discussions or surveys after each milestone release.
+
+## Risks & Mitigations
+- **Scope creep:** Prioritise roadmap items quarterly and cut features that do not advance the strategic themes.
+- **Data loss:** Before implementing advanced features, ship an export/import flow (JSON or CSV) so users can back up their data.
+- **Contributor onboarding:** Maintain up-to-date documentation and add a `CONTRIBUTING.md` guide to reduce friction for new collaborators.
+
+The roadmap is a living document—review it after each release to celebrate progress, adjust priorities, and ensure the project continues to serve its users effectively.


### PR DESCRIPTION
## Summary
- expand the README with a project overview, features, structure, and setup guidance
- add a dedicated ROADMAP.md detailing current gaps and staged improvement plans
- link to the roadmap from the README to highlight future work

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cae7d30568832887e8103883ff13ee